### PR TITLE
DSP-23519. Build on ubuntu:18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for base collectd install
-FROM ubuntu:16.04 as base
+FROM ubuntu:18.04 as base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG insight_version
@@ -10,6 +10,7 @@ RUN apt-get upgrade -y
 # Install all apt-get utils and required repos
 RUN apt-get update && \
     apt-get upgrade -y && \
+    apt-get install -y apt-utils && \
     # Install add-apt-repository
     apt-get install -y \
         software-properties-common && \
@@ -150,13 +151,14 @@ RUN cd /collectd && ./clean.sh && ./build.sh && ./configure \
         --disable-tokyotyrant \
         --disable-write_kafka \
         --with-perl-bindings="INSTALLDIRS=vendor INSTALL_BASE=" \
-        --without-libstatgrab \
-        --without-included-ltdl \
-        --without-libgrpc++ \
-        --without-libgps \
-        --without-liblua \
-        --without-libriemann \
-        --without-libsigrok && make && make install 
+        --with-libstatgrab=no \
+        --with-included-ltdl=no \
+        --with-libgrpc++=no \
+        --with-libgps=no \
+        --with-liblua=no \
+        --with-libriemann=no \
+        --with-libsigrok=no \
+        && make && make install 
 
 # pinned to last version of requests that supports python 2.7
 RUN pip install requests==2.27.1


### PR DESCRIPTION
Rationale for this change is to have more recent versions of libraries included in the final tarbal build using the Dockerfile. Especially openssl related: libcrypto.so and libssl.so.

Especially for openssl:
16.04 is using 1.0.2g while 18.04 uses 1.1.1-11.

Broader context is that DSE is including extracted tarball which then causes security scanners to find libs from collectd such as libcrypto.so to be source of CVEs.