### PR TITLE
DSP-23519. Use ubuntu:18.04 as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,6 +153,7 @@ RUN cd /collectd && ./clean.sh && ./build.sh && ./configure \
         --disable-zfs-arc \
         --disable-tokyotyrant \
         --disable-write_kafka \
+        --disable-barometer \
         --with-perl-bindings="INSTALLDIRS=vendor INSTALL_BASE=" \
         --without-libstatgrab \
         --without-included-ltdl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,29 +25,34 @@ RUN apt-get update && \
         git
 
 # Install dependencies
-RUN apt-get install -y build-essential \
-    libsnmp-dev bison libbison-dev flex autotools-dev \
-    pkg-config libtool libboost-all-dev libboost-test-dev \
-    libboost-program-options-dev libevent-dev automake g++ libssl-dev texinfo \
-        build-essential \
-        git \
-        curl \
-        libtool \
-        automake \
+RUN apt-get install -y \
         autoconf \
-        bison \
-        flex \
+        automake \
         autotools-dev \
-        libltdl-dev \
-        pkg-config \
+        bison \
+        build-essential \
+        curl \
+        default-jdk \
+        flex \
+        g++ \
+        git \
         iptables-dev \
         javahelper \
+        libatasmart-dev \
+        libbison-dev \
+        libboost-all-dev \
+        libboost-program-options-dev \
+        libboost-test-dev \
         libcurl4-gnutls-dev \
         libdbi0-dev \
         libesmtp-dev \
+        libevent-dev \
         libganglia1-dev \
         libgcrypt11-dev \
         libglib2.0-dev \
+        libi2c-dev \
+        libldap2-dev \
+        libltdl-dev \
         liblvm2-dev \
         libmemcached-dev \
         libmnl-dev \
@@ -59,26 +64,25 @@ RUN apt-get install -y build-essential \
         libpcap0.8-dev \
         libperl-dev \
         libpq-dev \
+        libprotobuf-c0-dev \
         librabbitmq-dev \
         librrd-dev \
         libsensors4-dev \
-        libsnmp-dev \
         libsnmp-dev>=5.4.2.1~dfsg-4~ \
+        libssl-dev \
+        libtool \
         libudev-dev \
+        libupsclient-dev \
         libvarnishapi-dev \
         libvirt-dev>=0.4.0-6 \
         libxml2-dev \
+        libyajl-dev \
         linux-libc-dev \
-        default-jdk \
+        pkg-config \
         protobuf-c-compiler \
         python-dev \
         python-pip \
-        libprotobuf-c0-dev \
-        libupsclient-dev \
-        libi2c-dev \
-        libyajl-dev \
-        libatasmart-dev \
-        libldap2-dev \
+        texinfo \
         wget
 
 #pull thrift (dependency)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for base collectd install
-FROM ubuntu:16.04 as base
+FROM ubuntu:18.04 as base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG insight_version

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -735,7 +735,7 @@ metric_family_create(char *name, data_set_t const *ds, value_list_t const *vl,
 
   msg->name = name;
 
-  char help[1024];
+  char help[4096];
   snprintf(
       help, sizeof(help),
       "write_prometheus plugin: '%s' Type: '%s', Dstype: '%s', Dsname: '%s'",


### PR DESCRIPTION
The goal of this change is to build collectd tarball on ubuntu 18.04  instead of 16.04 so that it has more modern versions of the libraries such as `libcrypt.so` or `libssl.so`.

In particular it is inspired by DSP-23517 where customer reported:
```
Path : /usr/share/dse/collectd/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
Reported version : 1.0.2g
Fixed version : 1.0.2i

Path : /usr/share/dse/collectd/lib/x86_64-linux-gnu/libssl.so.1.0.0
Reported version : 1.0.2g
Fixed version : 1.0.2i
```

In addition to building on 18.04 we need to:
1. disable barometer plugin, because it was causing `./configure` to fail and I do not think we will collect air pressure or temperature
2. fix the code so that it does not warn about potential memory override, because each warn is considered error with `-Wall` causing build to fail.